### PR TITLE
[feature] add SnsType Enum (사용자가 이용한 간편 로그인 Enum)

### DIFF
--- a/apps/mobiles/whilabel/lib/data/enums/sns_type.dart
+++ b/apps/mobiles/whilabel/lib/data/enums/sns_type.dart
@@ -1,0 +1,12 @@
+enum SnsType {
+  kakao("Kakao"),
+  instargram("Instargram"),
+  google("Google"),
+  apply("apply");
+
+  final String text;
+  const SnsType(this.text);
+
+  @override
+  String toString() => text;
+}


### PR DESCRIPTION
#### 관련 이슈 <!--  Notion Link-->
[아키텍쳐 개발](https://www.notion.so/flutter-99033e27e2904576a0802b555861a6f8?pvs=4l)


#### 변경 사항 및 이유 <!-- 변경한 내용과 그 이유를 적어주세요. --> 
flutter에서 사용할 간편 로그인이 어떤 플랫폼으로 들어왔는지 설정하기 위해서 만든 enum입니다.


사용자가 로그인한 간편로그인이 어떤것이지 enum을 사용해서
정의하였습니다. SnsType을 호출한 후 tostring()을 이용하여서 타입을
String으로 바꿀 수 있습니다

 < SnsType안에 정의된 enum>
 1. kakao("Kakao"),
 2. instargram("Instargram"),
 3. google("Google"),
 4. apply

#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 --> 
선언한 방식이 어떤지 알려주시면 감사하겠습니다


#### 참고 사항 <!-- 참고할 사항이 있다면 적어주세요. -->
feature/add-AppUser-model에 머지될 예정입니다.