### PR TITLE
[fature]  범용적으로 사용할 CurrentUserStatus() - provider 추가

### DIFF
--- a/apps/mobiles/whilabel/lib/domain/global_provider/current_user_state.dart
+++ b/apps/mobiles/whilabel/lib/domain/global_provider/current_user_state.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:whilabel/data/user/app_user.dart';
+import 'package:whilabel/domain/user/app_user_repository.dart';
+
+enum UserState {
+  initial, // 유저 추가 정보를 입력 x
+  notLogin, // 로그인 X 사용자
+  login, // 로그인 O 사용자
+}
+
+class CurrentUserStatus extends ChangeNotifier {
+  final AppUserRepository _repository;
+
+  UserState _userState = UserState.initial;
+  UserState get userState => _userState;
+
+  CurrentUserStatus(this._repository) {
+    updateUserState();
+  }
+
+  Future<AppUser?> getAppUser() async {
+    AppUser? result = await _repository.getCurrentUser();
+    print("Future<AppUser?> getAppUser() ====> $result");
+    return result;
+  }
+
+  Future<void> updateUserState() async {
+    final appUser = await _repository.getCurrentUser();
+    if (appUser == null) {
+      _userState = UserState.notLogin;
+      print("----- userState----\n ===>>>>>>  notLogin");
+    } else if (appUser.nickname == "") {
+      print("----- userState----\n ===>>>>>>  inital");
+
+      _userState = UserState.initial;
+    } else {
+      print("----- userState----\n ===>>>>>>  login");
+
+      _userState = UserState.login;
+    }
+
+    notifyListeners();
+  }
+}


### PR DESCRIPTION


#### 관련 이슈 <!--  Notion Link-->

#### 변경 사항 및 이유 <!-- 변경한 내용과 그 이유를 적어주세요. --> 
범용적으로 사용될 provider이기에 따로 viewModel에 사용하지 않고자 합니다
로그인뿐만 아니라 앱을 실행 시켰을 때도 사용됩니다,

#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 --> 

#### 참고 사항 <!-- 참고할 사항이 있다면 적어주세요. -->
