### PR TITLE
<fix> ListView의 정렬버튼 상태 유지

### DIFF
--- a/apps/mobiles/whilabel/lib/screens/home/list/widgets/whiskey_aligned_button_list.dart
+++ b/apps/mobiles/whilabel/lib/screens/home/list/widgets/whiskey_aligned_button_list.dart
@@ -18,17 +18,20 @@ class WhiskeyAlignedButtonList extends StatefulWidget {
 class _WhiskeyAlignedButtonListState extends State<WhiskeyAlignedButtonList> {
   @override
   Widget build(BuildContext context) {
+    final homeViewModel = context.watch<HomeViewModel>();
+    final homeState = homeViewModel.state;
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(
-          create: (context) => whiskyAlignedButtonStatus(),
+          create: (context) => WhiskyAlignedButtonStatus(initPostButtonOrder: homeState.listButtonOrder),
         ),
       ],
-      child: Consumer<whiskyAlignedButtonStatus>(
+      child: Consumer<WhiskyAlignedButtonStatus>(
         builder: (context, viewModel, _) => ListView.builder(
           scrollDirection: Axis.horizontal,
           itemCount: viewModel.buttonStates.length,
           itemBuilder: (context, index) {
+
             return Row(
               children: [
                 // _buttons[index],
@@ -61,7 +64,7 @@ class WhiskeyAlignedButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final alignedButtonsProvider = context.watch<whiskyAlignedButtonStatus>();
+    final alignedButtonsProvider = context.watch<WhiskyAlignedButtonStatus>();
     final homeViewModel = context.watch<HomeViewModel>();
 
     return ElevatedButton(

--- a/apps/mobiles/whilabel/lib/screens/home/view_model/local_provider/whisky_aligned_button_status.dart
+++ b/apps/mobiles/whilabel/lib/screens/home/view_model/local_provider/whisky_aligned_button_status.dart
@@ -20,16 +20,18 @@ class ButtonState {
   }
 }
 
-class whiskyAlignedButtonStatus extends ChangeNotifier {
-  // view에 보여지는 버튼의 수가 달라지면 이 변수도 변경해야 함.
-  final List<ButtonState> _buttonStates = [
-    ButtonState(postButtonOrder: PostButtonOrder.LATEST, isSelected: true),
-    ButtonState(postButtonOrder: PostButtonOrder.OLDEST, isSelected: false),
-    ButtonState(
-        postButtonOrder: PostButtonOrder.HiGHEST_RATING, isSelected: false),
-    ButtonState(
-        postButtonOrder: PostButtonOrder.LOWEST_RATiNG, isSelected: false),
-  ];
+class WhiskyAlignedButtonStatus extends ChangeNotifier {
+  final PostButtonOrder initPostButtonOrder;
+  List<ButtonState> _buttonStates = [];
+
+  WhiskyAlignedButtonStatus({required this.initPostButtonOrder}) {
+
+    _buttonStates = PostButtonOrder.values
+        .map((postButtonOrder) => ButtonState(
+        postButtonOrder: postButtonOrder,
+        isSelected: postButtonOrder == initPostButtonOrder ? true : false))
+        .toList();
+  }
 
   List<ButtonState> get buttonStates => _buttonStates;
 
@@ -37,7 +39,6 @@ class whiskyAlignedButtonStatus extends ChangeNotifier {
     ButtonState selectedButtonState = _buttonStates[index];
     _buttonStates[index] = _buttonStates[index]
         .copyWith(isSelected: !selectedButtonState.isSelected);
-
     notifyListeners();
   }
 


### PR DESCRIPTION
#### 관련 이슈 <!--  Notion Link-->


#### 변경 사항 및 이유 <!-- 변경한 내용과 그 이유를 적어주세요. --> 

ListView의 위스키 정렬 버튼을 누르고 다른 페이지나 뷰로 넘어가서 돌아오면 archivingPosts은 최근에 눌러둔 정렬 옵션이 유지되지만 버튼의 상태는 "최신순"으로 선택되어 있었다.

이번 commit을 동해 이러한 오류를 해결하였습니다
#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 --> 

#### 참고 사항 <!-- 참고할 사항이 있다면 적어주세요. -->
